### PR TITLE
SS 1091 Fix handling of deleted pods in a release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,16 @@ jobs:
         HADOLINT_RECURSIVE: "true"
 
     steps:
-      - uses: psf/black@stable
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run linter black
+        uses: psf/black@stable
         with:
           options: "-l 120 --check"
 
-      - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@v3.1.0
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: "Dockerfile*"
 
@@ -57,7 +61,7 @@ jobs:
 
 
   build:
-    name: Build a ci image
+    name: Build a CI image
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ "develop" ]
+    paths-ignore:
+      - '**.md'
+
+
+  # Adds ability to run this workflow manually
+  workflow_dispatch:
+
+
+jobs:
+
+  lint:
+    name: Run linting
+    runs-on: ubuntu-latest
+    env:
+        HADOLINT_RECURSIVE: "true"
+
+    steps:
+      - uses: psf/black@stable
+        with:
+          options: "-l 120 --check"
+
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: "Dockerfile*"
+
+
+  tests:
+    name: Run unit-tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.9, 3.11, 3.12]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+            python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m unittest discover -s tests
+
+
+  build:
+    name: Build a ci image
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag ci:$(date +%s)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run linter black
         uses: psf/black@stable
         with:
-          options: "-l 120 --check"
+          options: "--check"
 
       - name: Run hadolint
         uses: hadolint/hadolint-action@v3.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.11, 3.12]
+        python-version: [3.12]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.11, 3.12]
+        python-version: [3.12]
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,9 @@ node_modules
 .DS_Store
 .idea/
 
+# VSCode configurations
+.vscode
+
 # The media folder contents
 media/*
 !media/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ node_modules
 # The media folder contents
 media/*
 !media/.gitkeep
+
+# Local only files
+.local-only/

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -151,7 +151,7 @@ class EventListener:
 
     def check_status(self) -> bool:
         """
-        Checks the status of the EventListener.
+        Checks the status of the Serve API.
 
         Returns:
         - bool: True if the status is okay, False otherwise.
@@ -291,10 +291,10 @@ class EventListener:
 
     def get(self, url: str, headers: Union[None, dict] = None):
         """
-        Send a POST request to the specified URL with the provided data and token.
+        Send a GET request to the specified URL with the provided data and token.
 
         Args:
-            url (str): The URL to send the POST request to.
+            url (str): The URL to send the GET request to.
             data (dict): The data to be included in the POST request.
             header (None or dict): header for the request.
 

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -187,7 +187,27 @@ class EventListener:
 
         logger.info("Kubernetes client successfully set")
         self.client = client.CoreV1Api()
+
+        # self.list_all_pods()
+
         self.watch = watch.Watch()
+
+    def list_all_pods(self):
+        logger.info("Listing all pods and status codes")
+
+        try:
+            api_response = self.client.list_namespaced_pod(
+                self.namespace, limit=500, timeout_seconds=120, watch=False
+            )
+
+            for pod in api_response.items:
+                # TODO get_status() similar to logic in StatusData
+                # Make this a helper function and unit test?
+                print(f"{pod.metadata.name} with status {pod.status}")
+        except ApiException as e:
+            logger.warning(
+                f"Exception when calling CoreV1Api->list_namespaced_pod. {e}"
+            )
 
     def fetch_token(self):
         """

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -99,6 +99,8 @@ class EventListener:
         )
 
         max_retries = 10
+
+        # Duration in seconds to wait between retrying used when some exceptions occur
         retry_delay = 2
 
         if self.setup_complete:
@@ -251,7 +253,7 @@ class EventListener:
 
                 elif status_code in [401, 403]:
                     logger.warning(
-                        f"Recieved status code {status_code} - Fetching new token and retrying once"
+                        f"Received status code {status_code} - Fetching new token and retrying once"
                     )
                     self.token = self.fetch_token()
                     self._status_queue.token = self.token
@@ -263,17 +265,17 @@ class EventListener:
 
                 elif status_code in [404]:
                     logger.warning(
-                        f"Recieved status code {status_code} - {response.text}"
+                        f"Received status code {status_code} - {response.text}"
                     )
                     break
 
                 elif str(status_code).startswith("5"):
-                    logger.warning(f"Recieved status code {status_code}")
+                    logger.warning(f"Received status code {status_code}")
                     logger.warning(f"Retrying in {sleep} seconds")
                     time.sleep(sleep)
 
                 else:
-                    logger.warning(f"Recieved uncaught status code: {status_code}")
+                    logger.warning(f"Received uncaught status code: {status_code}")
 
             logger.info(f"POST returned - Status code: {status_code}")
 

--- a/serve_event_listener/status_data.py
+++ b/serve_event_listener/status_data.py
@@ -182,9 +182,11 @@ class StatusData:
         Returns:
             Dict: Updated status data.
         """
-        logger.debug(f"Release {release}. Status data before update:{status_data}. \
+        logger.debug(
+            f"Release {release}. Status data before update:{status_data}. \
                      release in status data? {release not in status_data}. \
-                    creation_timestamp={creation_timestamp}, deletion_timestamp={deletion_timestamp}")
+                    creation_timestamp={creation_timestamp}, deletion_timestamp={deletion_timestamp}"
+        )
         if (
             release not in status_data
             or creation_timestamp >= status_data[release]["creation_timestamp"]

--- a/serve_event_listener/status_data.py
+++ b/serve_event_listener/status_data.py
@@ -270,7 +270,7 @@ class StatusData:
 
         logger.debug(
             f"Release {release}. Status data before update:{status_data}. \
-                     release in status data? {release not in status_data}. \
+                     {(release in status_data)=}? \
                     creation_timestamp={creation_timestamp}, deletion_timestamp={deletion_timestamp}"
         )
         if (

--- a/serve_event_listener/status_data.py
+++ b/serve_event_listener/status_data.py
@@ -182,6 +182,9 @@ class StatusData:
         Returns:
             Dict: Updated status data.
         """
+        logger.debug(f"Release {release}. Status data before update:{status_data}. \
+                     release in status data? {release not in status_data}. \
+                    creation_timestamp={creation_timestamp}, deletion_timestamp={deletion_timestamp}")
         if (
             release not in status_data
             or creation_timestamp >= status_data[release]["creation_timestamp"]

--- a/serve_event_listener/status_queue.py
+++ b/serve_event_listener/status_queue.py
@@ -31,7 +31,9 @@ class StatusQueue:
                 release = status_data["release"]
                 new_status = status_data["new-status"]
                 if new_status == "Deleted":
-                    logger.info(f"Processing release: {release}. New status is Deleted!")
+                    logger.info(
+                        f"Processing release: {release}. New status is Deleted!"
+                    )
 
                 self.post_handler(
                     data=status_data,
@@ -40,7 +42,9 @@ class StatusQueue:
 
                 self.queue.task_done()
 
-                logger.debug(f"Processed queue successfully of release {release}, new status={new_status}")
+                logger.debug(
+                    f"Processed queue successfully of release {release}, new status={new_status}"
+                )
             except queue.Empty:
                 pass  # Continue looping if the queue is empty
 

--- a/serve_event_listener/status_queue.py
+++ b/serve_event_listener/status_queue.py
@@ -31,6 +31,7 @@ class StatusQueue:
                 release = status_data["release"]
                 new_status = status_data["new-status"]
                 if new_status == "Deleted":
+                    # TODO: Be careful with deleting releases! Check the truth in k8s.
                     logger.info(
                         f"Processing release: {release}. New status is Deleted!"
                     )

--- a/serve_event_listener/status_queue.py
+++ b/serve_event_listener/status_queue.py
@@ -30,8 +30,8 @@ class StatusQueue:
 
                 release = status_data["release"]
                 new_status = status_data["new-status"]
+
                 if new_status == "Deleted":
-                    # TODO: Be careful with deleting releases! Check the truth in k8s.
                     logger.info(
                         f"Processing release: {release}. New status is Deleted!"
                     )

--- a/serve_event_listener/status_queue.py
+++ b/serve_event_listener/status_queue.py
@@ -26,7 +26,12 @@ class StatusQueue:
     def process(self):
         while not self.stop_event.is_set():
             try:
-                status_data = self.queue.get(timeout=2)  # Wait for 1 second
+                status_data = self.queue.get(timeout=2)  # Wait for 2 seconds
+
+                release = status_data["release"]
+                new_status = status_data["new-status"]
+                if new_status == "Deleted":
+                    logger.info(f"Processing release: {release}. New status is Deleted!")
 
                 self.post_handler(
                     data=status_data,
@@ -35,7 +40,7 @@ class StatusQueue:
 
                 self.queue.task_done()
 
-                logger.debug("Processing queue successfully")
+                logger.debug(f"Processed queue successfully of release {release}, new status={new_status}")
             except queue.Empty:
                 pass  # Continue looping if the queue is empty
 

--- a/tests/create_pods.py
+++ b/tests/create_pods.py
@@ -88,3 +88,35 @@ class Pod(models.V1Pod):
 
     def get_current_time(self):
         return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+class PodStatus(models.V1PodStatus):
+
+    def __init__(self):
+        super().__init__()
+        self.init_container_statuses = []
+        self.container_statuses = []
+
+    def add_init_container_status(self, state: str, reason: str):
+        """
+        state one of: waiting,
+        reason="ContainerCreating"
+        """
+
+        if state == "waiting":
+            container_state = models.V1ContainerState(
+                waiting=models.V1ContainerStateWaiting(reason=reason)
+            )
+        else:
+            container_state = models.V1ContainerState()
+
+        container_status = models.V1ContainerStatus(
+            name="name",
+            state=container_state,
+            image="some image",
+            image_id="123",
+            ready=False,
+            restart_count=0,
+        )
+
+        self.init_container_statuses.append(container_status)

--- a/tests/create_pods.py
+++ b/tests/create_pods.py
@@ -97,15 +97,21 @@ class PodStatus(models.V1PodStatus):
         self.init_container_statuses = []
         self.container_statuses = []
 
-    def add_init_container_status(self, state: str, reason: str):
+    def add_init_container_status(self, state: str, reason: str, exit_code: int = 0):
         """
-        state one of: waiting,
-        reason="ContainerCreating"
+        Adds an init container status object to the list of init container statuses.
+        state one of: waiting, terminated
         """
 
         if state == "waiting":
             container_state = models.V1ContainerState(
                 waiting=models.V1ContainerStateWaiting(reason=reason)
+            )
+        elif state == "terminated":
+            container_state = models.V1ContainerState(
+                terminated=models.V1ContainerStateTerminated(
+                    exit_code=exit_code, reason=reason
+                )
             )
         else:
             container_state = models.V1ContainerState()
@@ -120,3 +126,39 @@ class PodStatus(models.V1PodStatus):
         )
 
         self.init_container_statuses.append(container_status)
+
+    def add_container_status(
+        self, state: str, reason: str, ready: bool = False, exit_code: int = 0
+    ):
+        """
+        Adds an regular, non-init container status object to the list of container statuses.
+        state one of: waiting, running
+        """
+
+        if state == "waiting":
+            container_state = models.V1ContainerState(
+                waiting=models.V1ContainerStateWaiting(reason=reason)
+            )
+        elif state == "running":
+            container_state = models.V1ContainerState(
+                running=models.V1ContainerStateRunning()
+            )
+        elif state == "terminated":
+            container_state = models.V1ContainerState(
+                terminated=models.V1ContainerStateTerminated(
+                    exit_code=exit_code, reason=reason
+                )
+            )
+        else:
+            container_state = models.V1ContainerState()
+
+        container_status = models.V1ContainerStatus(
+            name="name",
+            state=container_state,
+            image="some image",
+            image_id="123",
+            ready=ready,
+            restart_count=0,
+        )
+
+        self.container_statuses.append(container_status)

--- a/tests/test_status_data.py
+++ b/tests/test_status_data.py
@@ -154,5 +154,29 @@ class TestPodProcessing(unittest.TestCase):
         )
 
 
+class TestStatusDataUtilities(unittest.TestCase):
+    """Verifies the app status utility methods."""
+
+    def test_mapped_status(self):
+        """Test the mapped status codes.
+        Not all codes need to be tested.
+        """
+
+        actual = StatusData.get_mapped_status("CrashLoopBackOff")
+        self.assertEqual(actual, "Error")
+
+        actual = StatusData.get_mapped_status("Completed")
+        self.assertEqual(actual, "Retrying...")
+
+        actual = StatusData.get_mapped_status("ErrImagePull")
+        self.assertEqual(actual, "Image Error")
+
+    def test_mapped_status_nonexisting_code(self):
+        """Test the mapped status codes in a scenario with a non-existing code."""
+
+        actual = StatusData.get_mapped_status("NonexistingCode")
+        self.assertEqual(actual, "NonexistingCode")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_status_data.py
+++ b/tests/test_status_data.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 
 from serve_event_listener.status_data import StatusData
@@ -74,13 +75,19 @@ class TestPodProcessing(unittest.TestCase):
         self.new_pod.create(release)
         self.status_data.update({"object": self.new_pod})
 
+        time.sleep(0.01)
+
         self.pod.delete()
         self.status_data.update({"object": self.pod})
+
+        time.sleep(0.01)
 
         self.new_pod.running()
         self.status_data.update({"object": self.new_pod})
 
         self.assertEqual(self.status_data.status_data[release].get("status"), "Running")
+
+        time.sleep(0.01)
 
         self.new_pod.delete()
         self.status_data.update({"object": self.new_pod})
@@ -103,6 +110,8 @@ class TestPodProcessing(unittest.TestCase):
 
         assert self.status_data.status_data[release].get("status") == "Created"
 
+        time.sleep(0.01)
+
         self.pod.running()
         self.status_data.update({"object": self.pod})
         assert self.status_data.status_data[release].get("status") == "Running"
@@ -110,6 +119,9 @@ class TestPodProcessing(unittest.TestCase):
         # Pod: invalid_pod
         self.invalid_pod = Pod()
         self.invalid_pod.create(release)
+
+        time.sleep(0.01)
+
         self.invalid_pod.error_image_pull()
         self.status_data.update({"object": self.invalid_pod})
         assert self.status_data.status_data[release].get("status") == "Image Error"
@@ -119,6 +131,9 @@ class TestPodProcessing(unittest.TestCase):
         # Pod: valid_pod
         self.valid_pod = Pod()
         self.valid_pod.create(release)
+
+        time.sleep(0.01)
+
         self.valid_pod.running()
         self.status_data.update({"object": self.valid_pod})
         assert self.status_data.status_data[release].get("status") == "Running"

--- a/tests/test_status_data.py
+++ b/tests/test_status_data.py
@@ -87,6 +87,72 @@ class TestPodProcessing(unittest.TestCase):
 
         self.assertEqual(self.status_data.status_data[release].get("status"), "Deleted")
 
+    def test_valid_and_invalid_image_edits(self):
+        """
+        This scenario creates a pod, then creates a pod with an invalid image, and finally
+        it created a pod with a valid image.
+        After the third pod is created, the first two are deleted.
+        This occurs when a user chnages the image to an invalid image and then valid image.
+        """
+
+        release = "r-valid-invalid-images"
+
+        # Pod: pod
+        self.pod.create(release)
+        self.status_data.update({"object": self.pod})
+
+        assert self.status_data.status_data[release].get("status") == "Created"
+
+        self.pod.running()
+        self.status_data.update({"object": self.pod})
+        assert self.status_data.status_data[release].get("status") == "Running"
+
+        # Pod: invalid_pod
+        self.invalid_pod = Pod()
+        self.invalid_pod.create(release)
+        self.invalid_pod.error_image_pull()
+        self.status_data.update({"object": self.invalid_pod})
+        assert self.status_data.status_data[release].get("status") == "Image Error"
+
+        # Now there are two pods in the release, one older Running and one newer Image Error
+
+        # Pod: valid_pod
+        self.valid_pod = Pod()
+        self.valid_pod.create(release)
+        self.valid_pod.running()
+        self.status_data.update({"object": self.valid_pod})
+        assert self.status_data.status_data[release].get("status") == "Running"
+
+        # The first two pods are deleted but the last pod should remain running
+        self.pod.delete()
+        self.invalid_pod.delete()
+
+        self.status_data.update({"object": self.pod})
+
+        msg = f"Release created ts={self.status_data.status_data[release].get("creation_timestamp")}, \
+                deleted ts={self.status_data.status_data[release].get("deletion_timestamp")}"
+
+        print(msg)
+
+        self.assertEqual(
+            self.status_data.status_data[release].get("status"),
+            "Running",
+            f"Release should be Running after delete of first pod, \
+                         ts pod deleted={self.pod.metadata.deletion_timestamp} vs \
+                         ts invalid_pod deleted={self.invalid_pod.metadata.deletion_timestamp} vs \
+                         ts valid_pod created={self.valid_pod.metadata.creation_timestamp}, {msg}",
+        )
+
+        self.status_data.update({"object": self.invalid_pod})
+        self.assertEqual(
+            self.status_data.status_data[release].get("status"),
+            "Running",
+            f"Release should be Running after delete of 2nd invalid pod, \
+                         ts pod deleted={self.pod.metadata.deletion_timestamp} vs \
+                         ts invalid_pod deleted={self.invalid_pod.metadata.deletion_timestamp} vs \
+                         ts valid_pod created={self.valid_pod.metadata.creation_timestamp}, {msg}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug that incorrectly sets the app status to Deleted. This can occur in several scenarios for example if the app image is changed to an invalid image and then back to a valid image.

A function to fetch the current status directly from k8s via the k8s API client is introduced. This is used in special situations when the k8s stream seems to indicate that a pod has been deleted to make sure this is the case.

Also introduces a CI action and extended unit test coverage of the app status logic.