### PR TITLE
Send unmapped k8s status codes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run linter black
         uses: psf/black@stable
@@ -65,6 +65,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag ci:$(date +%s)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,7 +49,7 @@ jobs:
   publish:
     name: Publish to ghcr.io
     needs: tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         id: meta
         with:
           images: ${{ matrix.image }}
@@ -73,14 +73,14 @@ jobs:
             type=raw,value=${{ github.ref_name }}
 
       - name: Log in
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: "${{ github.event_name != 'pull_request' }}"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Kubernetes Event Listener by Serve is a service designed to monitor changes 
 
 ## Development
 
-This repository uses two branches: main and develop. Develop in branch develop, then create a PR to merge develop into the main branch. To release a new version of the event-listener, first tag the latest commit. When the tag is pushed to origin, a github action is run automatically and publishes a new package called event-listener.
+This repository uses two branches: main and develop. Develop in branch develop, then create a PR to merge develop into the main branch. To release a new version of the event-listener, first tag the latest commit. When the tag is pushed to origin, a github action is run automatically and publishes a new package which is a docker image called event-listener.
 
 ## Host Machine Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Serve Event Listener
+# Kubernetes Event Listener by Serve
 
-The Serve Event Listener is a service designed to monitor changes in Kubernetes and automatically update corresponding `AppInstance` and `AppStatus` objects in the Serve platform. This README provides detailed instructions on how to run the service on both a host machine and within a Docker container.
+The Kubernetes Event Listener by Serve is a service designed to monitor changes in Kubernetes and automatically send the latest information to another application for processing. This README provides detailed instructions on how to run the service on both a host machine and within a Docker container.
+
+## Development
+
+This repository uses two branches: main and develop. Develop in branch develop, then create a PR to merge develop into the main branch. To release a new version of the event-listener, first tag the latest commit. When the tag is pushed to origin, a github action is run automatically and publishes a new package called event-listener.
 
 ## Host Machine Setup
 
@@ -14,11 +18,11 @@ Set the `KUBECONFIG` environment variable to point to your Kubernetes cluster co
 
 ```bash
 export KUBECONFIG=/path/to/cluster.conf
-export USERNAME=<serve admin username>
-export PASSWORD=<serve admin password>
-export BASE_URL=<serve URL (no trailing slash)>
+export BASE_URL=<Retriever URL (Serve) (no trailing slash)>
 export TOKEN_API_ENDPOINT=<end point for fetching token> (optional, is set to BASE_URL + "/api/v1/token-auth/" if not defined)
 export APP_STATUS_API_ENDPOINT=<end point for status updates> (optional, is set to BASE_URL + "/api/v1/app-status/" if not defined)
+export USERNAME=<admin username (Serve)>
+export PASSWORD=<admin password (Serve)>
 ```
 
 To retrieve additional log messages, set:

--- a/serve_event_listener/status_data.py
+++ b/serve_event_listener/status_data.py
@@ -154,8 +154,8 @@ class StatusData:
             f"Getting the nr of pods in release {release} directly from k8s via the api client"
         )
 
+        """
         apps_v1 = client.AppsV1Api()
-
         deployments = apps_v1.list_namespaced_deployment(
             namespace=self.namespace, label_selector=f"release={release}"
         )
@@ -166,10 +166,12 @@ class StatusData:
         # Assume the first deployment is the one we are interested in
         deployment = deployments.items[0]
         deployment_name = deployment.metadata.name
+        """
 
         pods = self.k8s_api_client.list_namespaced_pod(
             namespace=self.namespace,
-            label_selector=f"app={deployment_name}",
+            # label_selector=f"app={deployment_name}",
+            label_selector=f"app={release}",
             limit=response_limit,
             timeout_seconds=120,
             watch=False,
@@ -374,10 +376,15 @@ class StatusData:
                             release
                         )
                         logger.debug(
-                            f"Fetched {len(pod_phases)} for release {release} from k8s"
+                            f"Fetched {len(pod_phases)} pod phases for release {release} from k8s"
                         )
 
-                        if len(pod_phases) <= 1:
+                        for phase in pod_phases:
+                            if phase == "Running":
+                                status = "Running"
+                                break
+
+                        if status != "Running" and len(pod_phases) <= 1:
                             # There are no other pods in this release. Set status to Deleted
                             status = "Deleted"
 

--- a/serve_event_listener/status_data.py
+++ b/serve_event_listener/status_data.py
@@ -369,7 +369,7 @@ class StatusData:
                     if self.k8s_api_client is None:
                         logger.warning("No k8s API client: k8s_api_client is None")
 
-                    if self.k8s_api_client:
+                    else:
                         # Only use if the k8s client api has been set
                         # Unit tests for example do not currently set a k8s api
                         pod_phases = self.fetch_pod_phases_in_release_from_k8s_api(

--- a/serve_event_listener/status_data.py
+++ b/serve_event_listener/status_data.py
@@ -3,7 +3,6 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Tuple, Union
 
-import requests
 from kubernetes import client
 from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models import V1PodStatus
@@ -154,20 +153,8 @@ class StatusData:
             f"Getting the nr of pods in release {release} directly from k8s via the api client"
         )
 
-        """
-        apps_v1 = client.AppsV1Api()
-        deployments = apps_v1.list_namespaced_deployment(
-            namespace=self.namespace, label_selector=f"release={release}"
-        )
-
-        if not deployments.items:
-            return []
-
-        # Assume the first deployment is the one we are interested in
-        deployment = deployments.items[0]
-        deployment_name = deployment.metadata.name
-        """
-
+        # Using label_selector with app=release because no pods were selected using the
+        # app=deployment_name
         pods = self.k8s_api_client.list_namespaced_pod(
             namespace=self.namespace,
             # label_selector=f"app={deployment_name}",

--- a/tests/test_status_data.py
+++ b/tests/test_status_data.py
@@ -49,12 +49,17 @@ class TestPodProcessing(unittest.TestCase):
         assert (
             self.status_data.status_data[release].get("status") == "ContainerCreating"
         )  # before: Created
+
+        time.sleep(0.01)
+
         self.pod.delete()
 
         event = {"object": self.pod}
         self.status_data.update(event)
 
-        assert self.status_data.status_data[release].get("status") == "Deleted"
+        assert (
+            self.status_data.status_data[release].get("status") == "Terminated"
+        )  # before: Deleted
 
     def test_pod_running(self):
         release = "r1234567"
@@ -119,7 +124,9 @@ class TestPodProcessing(unittest.TestCase):
         self.new_pod.delete()
         self.status_data.update({"object": self.new_pod})
 
-        self.assertEqual(self.status_data.status_data[release].get("status"), "Deleted")
+        self.assertEqual(
+            self.status_data.status_data[release].get("status"), "Terminated"
+        )  # before: Deleted
 
     @unittest.skip(
         "This test no longer works after we rely on k8s truth for deletions."
@@ -130,7 +137,7 @@ class TestPodProcessing(unittest.TestCase):
         it creates a pod with a valid image.
         After the third pod is created, the first two are deleted.
         Finally the valid pod is also deleted.
-        This occurs when a user chnages the image to an invalid image and then valid image.
+        This occurs when a user changes the image to an invalid image and then valid image.
         """
 
         # TODO: Consider re-enabling this test by for example creating a parallel data structure
@@ -142,7 +149,9 @@ class TestPodProcessing(unittest.TestCase):
         self.pod.create(release)
         self.status_data.update({"object": self.pod})
 
-        assert self.status_data.status_data[release].get("status") == "Created"
+        assert (
+            self.status_data.status_data[release].get("status") == "ContainerCreating"
+        )
 
         time.sleep(0.01)
 


### PR DESCRIPTION
This PR modifies the event listener to send unconverted k8s status codes to any listening receiver (Serve). It also bumps some versions of github actions used. 