### PR TITLE
SS 1516 Fix error release not in statusdata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run isort  # pip-based (flexible)
+        run: |
+          pip install isort
+          isort . --check --diff --profile black
+
       - name: Run linter black
         uses: psf/black@stable
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+    types: [opened, reopened]
     branches: [ "*" ]
     paths-ignore:
       - '**.md'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.19
+FROM python:3.12-alpine3.20
 LABEL maintainer="serve@scilifelab.se"
 
 ARG USER=serve
@@ -8,8 +8,8 @@ WORKDIR $HOME
 
 COPY requirements.txt .
 
-RUN apk add --update --no-cache \
-    && pip install --no-cache-dir --upgrade pip==25.0.1\
+RUN apk add --no-cache curl \
+    && pip install --no-cache-dir --upgrade "pip~=25.2" \
     && pip install --no-cache-dir -r requirements.txt \
     && rm requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $HOME
 
 COPY requirements.txt .
 
-RUN apk add --no-cache curl \
+RUN apk add --no-cache curl=8.12.1-r0 \
     && pip install --no-cache-dir --upgrade "pip~=25.2" \
     && pip install --no-cache-dir -r requirements.txt \
     && rm requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,31 @@
 FROM python:3.12-alpine3.20
 LABEL maintainer="serve@scilifelab.se"
 
-ARG USER=serve
-ARG HOME=/home/$USER
+RUN addgroup -S serve && adduser -S -G serve serve
 
-WORKDIR $HOME
+WORKDIR /app
 
-COPY requirements.txt .
+COPY requirements.txt /app/requirements.txt
 
-RUN apk add --no-cache curl=8.12.1-r0 \
+# Install runtime deps
+RUN apk add --no-cache \
+        curl=8.12.1-r0 \
+        jq=1.7.1-r0 \
     && pip install --no-cache-dir --upgrade "pip~=25.2" \
     && pip install --no-cache-dir -r requirements.txt \
     && rm requirements.txt
 
-RUN adduser -D $USER --home $HOME
+# Copy source, owned by non-root user
+COPY --chown=serve:serve serve_event_listener/ /app/serve_event_listener/
 
-COPY /serve_event_listener/ $HOME/
+# Make sure the package root is importable
+ENV PYTHONPATH=/app
 
-ENTRYPOINT [ "python3", "main.py" ]
+# Drop privileges for runtime
+USER serve
+
+# Run the package module so imports resolve properly
+ENTRYPOINT ["python3", "-m", "serve_event_listener.main"]
+
+# Sensible defaults; can override container.args
+CMD ["--namespace", "default", "--label-selector", "type=app"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export TEST_LOG_STREAM=sys.stdout
 Navigate to the project directory and execute the following command to run the service:
 
 ```bash
-python3 ./serve_event_listener/main.py --namespace <some-namespace> --label-selector <some label selector>
+python3 -m serve_event_listener.main --namespace <some-namespace> --label-selector <some label selector>
 ```
 
 ### Running the unit tests
@@ -82,8 +82,8 @@ docker build -t <image name>:<image tag> .
 Run the Docker container with the mounted `cluster.conf` file and provide necessary environment variables:
 
 ```bash
-docker run --rm -v $PWD/cluster.conf:/home/serve/cluster.conf \
-    --env KUBECONFIG=/home/serve/cluster.conf \
+docker run --rm -v $PWD/cluster.conf:/app/cluster.conf \
+    --env KUBECONFIG=/app/cluster.conf \
     --env USERNAME=admin@test.com \
     ...(set all env from above) \
      <image name>:<image tag> \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ git fetch
 git rebase origin/main
 ```
 
+Verify that the code adheres to the style guidelines and code analysis rules:
+```bash
+flake8 .
+black . --check
+hadolint Dockerfile
+```
+
 When the work is ready to be merged to main, create a PR to merge your feature branch into the main branch.
 
 To release a new version of the event-listener, first tag the latest commit. When the tag is pushed to origin, a github action is run automatically and publishes a new package which is a docker image called event-listener.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ git rebase origin/main
 Verify that the code adheres to the style guidelines and code analysis rules:
 ```bash
 flake8 .
+isort .
 black . --check
 hadolint Dockerfile
 ```

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -191,7 +191,7 @@ class EventListener:
                     time.sleep(retry_delay)
 
                     # We no longer treat all ApiExceptions as flow-stopping errors
-                    #retries += 1
+                    # retries += 1
 
                 except ValueError as e:
                     # Handle value errors related to data processing
@@ -292,7 +292,10 @@ class EventListener:
                 release = pod.metadata.labels.get("release")
                 app_status = StatusData.determine_status_from_k8s(pod.status)
                 logger.info(
-                    "Release=%s, %s with status %s", release, pod.metadata.name, app_status
+                    "Release=%s, %s with status %s",
+                    release,
+                    pod.metadata.name,
+                    app_status,
                 )
         except ApiException as e:
             logger.warning(
@@ -350,7 +353,11 @@ class EventListener:
             for sleep in [1, 2, 4]:
                 # Use connect timeout as 3.05s and read timeout of 20s
                 response = requests.post(
-                    url=url, json=data, headers=headers, verify=False, timeout=(3.05, 20)
+                    url=url,
+                    json=data,
+                    headers=headers,
+                    verify=False,
+                    timeout=(3.05, 20),
                 )
                 status_code = response.status_code
 
@@ -364,7 +371,8 @@ class EventListener:
 
                 elif status_code in [401, 403]:
                     logger.warning(
-                        "Received status code %s - Fetching new token and retrying once", status_code
+                        "Received status code %s - Fetching new token and retrying once",
+                        status_code,
                     )
                     self.token = self.fetch_token()
                     self._status_queue.token = self.token
@@ -395,7 +403,9 @@ class EventListener:
             response = None
 
         except requests.exceptions.ReadTimeout as e:
-            logger.warning("Unable to read response from POST to server. ReadTimeout: %s", e)
+            logger.warning(
+                "Unable to read response from POST to server. ReadTimeout: %s", e
+            )
             response = None
 
         except requests.exceptions.Timeout as e:
@@ -426,7 +436,9 @@ class EventListener:
         """
         try:
             # Use connect timeout as 3.05s and read timeout of 20s
-            response = requests.get(url=url, headers=headers, verify=False, timeout=(3.05, 20))
+            response = requests.get(
+                url=url, headers=headers, verify=False, timeout=(3.05, 20)
+            )
             logger.info("GET returned status code: %s", response.status_code)
 
         except requests.exceptions.ConnectTimeout as e:
@@ -434,7 +446,9 @@ class EventListener:
             response = None
 
         except requests.exceptions.ReadTimeout as e:
-            logger.warning("Unable to read response from GET to server. ReadTimeout: %s", e)
+            logger.warning(
+                "Unable to read response from GET to server. ReadTimeout: %s", e
+            )
             response = None
 
         except requests.exceptions.Timeout as e:

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -131,7 +131,9 @@ class EventListener:
                             self.get_resource_version_from_pod_list()
                         )
 
-                    logger.debug(f"Done getting resource version: {self.resource_version}")
+                    logger.debug(
+                        f"Done getting resource version: {self.resource_version}"
+                    )
                     # Stream events with resource_version
                     # Use a timeout of 4 minutes to avoid staleness
                     for event in self.watch.stream(

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -244,8 +244,8 @@ class EventListener:
         """
         logger.info("Setting up Kubernetes client")
         try:
-            if KUBECONFIG:
-                logger.debug("Attempting to load KUBECONFIG")
+            if KUBECONFIG and os.path.exists(KUBECONFIG):
+                logger.debug("Loading kubeconfig from KUBECONFIG = %s", KUBECONFIG)
                 config.load_kube_config(KUBECONFIG)
             else:
                 logger.warning(

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -126,10 +126,12 @@ class EventListener:
                 try:
                     # Start fresh if no resourceVersion (initial run or after 410)
                     if not self.resource_version:
+                        logger.debug("No k8s resource version yet set. Getting now.")
                         self.resource_version = (
                             self.get_resource_version_from_pod_list()
                         )
 
+                    logger.debug(f"Done getting resource version: {self.resource_version}")
                     # Stream events with resource_version
                     # Use a timeout of 4 minutes to avoid staleness
                     for event in self.watch.stream(
@@ -213,6 +215,7 @@ class EventListener:
         Returns:
         - bool: True if the status is okay, False otherwise.
         """
+        logger.debug("Verifying that the server API is up and available.")
         response = self.get(url=BASE_URL + "/openapi/v1/are-you-there")
 
         if response is None:

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -6,14 +6,15 @@ from typing import Any, Optional, Union
 
 import requests
 import urllib3
-from urllib3.exceptions import HTTPError
 from kubernetes import client, config, watch
 from kubernetes.client.exceptions import ApiException
-from serve_event_listener.http_client import get as http_get, make_session
+from urllib3.exceptions import HTTPError
+
+from serve_event_listener.http_client import get as http_get
+from serve_event_listener.http_client import make_session
 from serve_event_listener.http_client import post as http_post
 from serve_event_listener.status_data import StatusData
 from serve_event_listener.status_queue import StatusQueue
-
 
 logger = logging.getLogger(__name__)
 

--- a/serve_event_listener/event_listener.py
+++ b/serve_event_listener/event_listener.py
@@ -6,11 +6,12 @@ from typing import Any, Optional, Union
 
 import requests
 import urllib3
+from urllib3.exceptions import HTTPError
 from kubernetes import client, config, watch
 from kubernetes.client.exceptions import ApiException
-from status_data import StatusData
-from status_queue import StatusQueue
-from urllib3.exceptions import HTTPError
+from serve_event_listener.status_data import StatusData
+from serve_event_listener.status_queue import StatusQueue
+
 
 logger = logging.getLogger(__name__)
 

--- a/serve_event_listener/http_client/__init__.py
+++ b/serve_event_listener/http_client/__init__.py
@@ -1,0 +1,4 @@
+from .client import _request, get, post
+from .session import make_session
+
+__all__ = ["make_session", "_request", "get", "post"]

--- a/serve_event_listener/http_client/client.py
+++ b/serve_event_listener/http_client/client.py
@@ -2,7 +2,8 @@
 
 import logging
 import time
-from typing import Optional, Mapping, Any, Tuple, Callable
+from typing import Any, Callable, Mapping, Optional, Tuple
+
 import requests
 
 logger = logging.getLogger(__name__)

--- a/serve_event_listener/http_client/client.py
+++ b/serve_event_listener/http_client/client.py
@@ -22,6 +22,7 @@ def _request(
     timeout: Timeout = (3.05, 20.0),
     backoff_seconds=(1, 2, 4),
     token_fetcher: Optional[Callable[[], str]] = None,  # optional
+    auth_scheme: str = "Token",  # can easily change to Bearer in the future
     sleep_fn: Callable[[float], None] = time.sleep,  # overridable in tests
 ) -> Optional[requests.Response]:
     merged_headers = {**(session.headers or {}), **(headers or {})}
@@ -34,7 +35,7 @@ def _request(
     if token_fetcher and "Authorization" not in merged_headers:
         tok = token_fetcher()
         if tok:
-            merged_headers["Authorization"] = f"Bearer {tok}"
+            merged_headers["Authorization"] = f"{auth_scheme} {tok}"
 
     try:
         last = None
@@ -58,7 +59,7 @@ def _request(
             if code in (401, 403) and token_fetcher and not refreshed:
                 tok = token_fetcher()
                 if tok:
-                    merged_headers["Authorization"] = f"Bearer {tok}"
+                    merged_headers["Authorization"] = f"Token {tok}"
                 refreshed = True
                 sleep_fn(delay)
                 continue

--- a/serve_event_listener/http_client/client.py
+++ b/serve_event_listener/http_client/client.py
@@ -1,0 +1,133 @@
+"""HTTP client wrappers providing retries, token refresh, and logging."""
+
+import logging
+import time
+from typing import Optional, Mapping, Any, Tuple, Callable
+import requests
+
+logger = logging.getLogger(__name__)
+
+Timeout = Tuple[float, float]
+
+
+def _request(
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    params: Optional[Mapping[str, Any]] = None,
+    json: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    verify: bool = True,
+    timeout: Timeout = (3.05, 20.0),
+    backoff_seconds=(1, 2, 4),
+    token_fetcher: Optional[Callable[[], str]] = None,  # optional
+    sleep_fn: Callable[[float], None] = time.sleep,  # overridable in tests
+) -> Optional[requests.Response]:
+    merged_headers = {**(session.headers or {}), **(headers or {})}
+
+    if not backoff_seconds:
+        raise ValueError("backoff_seconds must contain at least one delay value")
+
+    # If token_fetcher is provided but Authorization is missing, fetch once
+    refreshed = False
+    if token_fetcher and "Authorization" not in merged_headers:
+        tok = token_fetcher()
+        if tok:
+            merged_headers["Authorization"] = f"Bearer {tok}"
+
+    try:
+        last = None
+        for i, delay in enumerate(backoff_seconds):
+            resp = session.request(
+                method=method.upper(),
+                url=url,
+                params=params,
+                json=json,
+                headers=merged_headers or None,
+                verify=verify,
+                timeout=timeout,
+            )
+            code = resp.status_code
+            last = resp
+
+            if 200 <= code < 300:
+                return resp
+            if code in (400, 404):
+                return resp
+            if code in (401, 403) and token_fetcher and not refreshed:
+                tok = token_fetcher()
+                if tok:
+                    merged_headers["Authorization"] = f"Bearer {tok}"
+                refreshed = True
+                sleep_fn(delay)
+                continue
+            if 500 <= code < 600:
+                # Only sleep if there’s another attempt
+                if i < len(backoff_seconds) - 1:
+                    sleep_fn(delay)
+                    continue
+            return resp  # other statuses returned as-is
+        return last
+
+    except requests.exceptions.ConnectTimeout as e:
+        logger.warning("ConnectTimeout: %s", e)
+    except requests.exceptions.ReadTimeout as e:
+        logger.warning("ReadTimeout: %s", e)
+    except requests.exceptions.Timeout as e:
+        logger.warning("Timeout: %s", e)
+    except requests.exceptions.ConnectionError as e:
+        logger.warning("ConnectionError: %s", e)
+    except requests.exceptions.RequestException as e:
+        logger.warning("RequestException: %s", e)
+    return None
+
+
+def get(session: requests.Session, url: str, **kwargs) -> Optional[requests.Response]:
+    """
+    Send a POST request using the provided requests.Session.
+
+    This is a thin wrapper around `_request` that applies standard retry and
+    error-handling logic for POST calls. The `data` argument is sent as JSON
+    in the request body.
+
+    Args:
+        session (requests.Session): A configured requests session (e.g., from
+            `make_session`).
+        url (str): The target URL for the POST request.
+        data (dict, optional): A dictionary of data to serialize as JSON in the
+            request body. Defaults to an empty dict.
+        **kwargs: Additional keyword arguments forwarded to `_request`
+            (e.g., headers, timeout, verify, backoff_seconds, token_fetcher).
+
+    Returns:
+        Optional[requests.Response]: The HTTP response object if a request was
+        successfully made, or None if a network exception occurred.
+    """
+    return _request(session, "GET", url, **kwargs)
+
+
+def post(
+    session: requests.Session, url: str, *, data=None, **kwargs
+) -> Optional[requests.Response]:
+    """
+    Send a POST request using the provided requests.Session.
+
+    This is a thin wrapper around `_request` that applies standard retry and
+    error-handling logic for POST calls. The `data` argument is sent as JSON
+    in the request body.
+
+    Args:
+        session (requests.Session): A configured requests session (e.g., from
+            `make_session`).
+        url (str): The target URL for the POST request.
+        data (dict, optional): A dictionary of data to serialize as JSON in the
+            request body. Defaults to an empty dict.
+        **kwargs: Additional keyword arguments forwarded to `_request`
+            (e.g., headers, timeout, verify, backoff_seconds, token_fetcher).
+
+    Returns:
+        Optional[requests.Response]: The HTTP response object if a request was
+        successfully made, or None if a network exception occurred.
+    """
+    return _request(session, "POST", url, json=(data or {}), **kwargs)

--- a/serve_event_listener/http_client/session.py
+++ b/serve_event_listener/http_client/session.py
@@ -1,0 +1,63 @@
+"""Configure requests.Session with retries, adapters, and TLS settings."""
+
+from typing import Mapping, Optional, Tuple
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+Timeout = Tuple[float, float]
+
+
+def make_session(
+    *,
+    default_headers: Optional[Mapping[str, str]] = None,
+    token: Optional[str] = None,
+    total_retries: int = 3,
+) -> requests.Session:
+    """
+    Create and configure a requests.Session with retry logic and optional headers.
+
+    The returned session is preconfigured with:
+      - Default headers (merged with any provided by the caller).
+      - An optional Bearer token in the Authorization header.
+      - An HTTPAdapter mounted on both HTTP and HTTPS with a Retry policy.
+
+    Args:
+        default_headers (Mapping[str, str], optional): Extra headers to add to
+            the session (e.g., {"Accept": "application/json"}).
+        token (str, optional): Bearer token to include in the Authorization header.
+        total_retries (int, optional): Total number of retries for failed
+            connections and retryable status codes (default is 3).
+
+    Returns:
+        requests.Session: A configured session ready for use with get/post wrappers.
+    """
+    s = requests.Session()
+    s.headers.update({"Accept": "application/json"})
+    if default_headers:
+        s.headers.update(default_headers)
+    if token:
+        s.headers["Authorization"] = f"Bearer {token}"
+
+    retry = Retry(
+        total=total_retries,
+        connect=total_retries,
+        read=total_retries,
+        backoff_factor=0.5,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=frozenset(
+            [
+                "HEAD",
+                "GET",
+                "PUT",
+                "DELETE",
+                "OPTIONS",
+                "TRACE",
+                "POST",
+            ]
+        ),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s

--- a/serve_event_listener/http_client/session.py
+++ b/serve_event_listener/http_client/session.py
@@ -1,6 +1,7 @@
 """Configure requests.Session with retries, adapters, and TLS settings."""
 
 from typing import Mapping, Optional, Tuple
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry

--- a/serve_event_listener/http_client/session.py
+++ b/serve_event_listener/http_client/session.py
@@ -19,13 +19,13 @@ def make_session(
 
     The returned session is preconfigured with:
       - Default headers (merged with any provided by the caller).
-      - An optional Bearer token in the Authorization header.
+      - An optional Bearer/Token token in the Authorization header.
       - An HTTPAdapter mounted on both HTTP and HTTPS with a Retry policy.
 
     Args:
         default_headers (Mapping[str, str], optional): Extra headers to add to
             the session (e.g., {"Accept": "application/json"}).
-        token (str, optional): Bearer token to include in the Authorization header.
+        token (str, optional): Bearer/Token token to include in the Authorization header.
         total_retries (int, optional): Total number of retries for failed
             connections and retryable status codes (default is 3).
 
@@ -37,7 +37,7 @@ def make_session(
     if default_headers:
         s.headers.update(default_headers)
     if token:
-        s.headers["Authorization"] = f"Bearer {token}"
+        s.headers["Authorization"] = f"Token {token}"
 
     retry = Retry(
         total=total_retries,

--- a/serve_event_listener/main.py
+++ b/serve_event_listener/main.py
@@ -1,9 +1,8 @@
 import argparse
 import logging
 import os
-
 from colorlog import ColoredFormatter
-from .event_listener import EventListener
+from serve_event_listener.event_listener import EventListener
 
 # Configure the logger
 formatter = ColoredFormatter(
@@ -50,7 +49,7 @@ def parse_args():
     return parser.parse_args()
 
 
-if __name__ == "__main__":
+def run(namespace: str, label_selector: str) -> None:
     args = parse_args()
 
     start_message = (
@@ -70,3 +69,12 @@ if __name__ == "__main__":
     event_listener = EventListener(args.namespace, args.label_selector)
     event_listener.setup()
     event_listener.listen()
+
+
+def main():
+    args = parse_args()
+    run(args.namespace, args.label_selector)
+
+
+if __name__ == "__main__":
+    main()

--- a/serve_event_listener/main.py
+++ b/serve_event_listener/main.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from colorlog import ColoredFormatter
-from event_listener import EventListener
+from .event_listener import EventListener
 
 # Configure the logger
 formatter = ColoredFormatter(

--- a/serve_event_listener/main.py
+++ b/serve_event_listener/main.py
@@ -53,11 +53,21 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
-    logger.info(
-        "\n\n\t{}\n\t  Starting Kubernetes Event Listener \n\t  Namespace: {}\n\t  Label Selector: {}\n\t{}\n".format(
-            "#" * 40, args.namespace, args.label_selector, "#" * 40
-        )
+    start_message = (
+        "\n\n\t{}\n\t"
+        "Starting Kubernetes Event Listener \n\t"
+        "Namespace: {}\n\t"
+        "Label Selector: {}\n\t"
+        "debug: {}\n\t"
+        "{}\n"
     )
+    logger.info(start_message.format(
+        "#" * 40,
+        args.namespace,
+        args.label_selector,
+        DEBUG,
+        "#" * 40
+    ))
 
     event_listener = EventListener(args.namespace, args.label_selector)
     event_listener.setup()

--- a/serve_event_listener/main.py
+++ b/serve_event_listener/main.py
@@ -61,13 +61,11 @@ if __name__ == "__main__":
         "debug: {}\n\t"
         "{}\n"
     )
-    logger.info(start_message.format(
-        "#" * 40,
-        args.namespace,
-        args.label_selector,
-        DEBUG,
-        "#" * 40
-    ))
+    logger.info(
+        start_message.format(
+            "#" * 40, args.namespace, args.label_selector, DEBUG, "#" * 40
+        )
+    )
 
     event_listener = EventListener(args.namespace, args.label_selector)
     event_listener.setup()

--- a/serve_event_listener/main.py
+++ b/serve_event_listener/main.py
@@ -1,7 +1,9 @@
 import argparse
 import logging
 import os
+
 from colorlog import ColoredFormatter
+
 from serve_event_listener.event_listener import EventListener
 
 # Configure the logger

--- a/serve_event_listener/status_queue.py
+++ b/serve_event_listener/status_queue.py
@@ -22,14 +22,13 @@ class StatusQueue:
 
         self.session = session
         self.url = url
-        # self.post_handler = post_handler
         self.token = token
         self.token_fetcher = token_fetcher
 
     def add(self, status_data) -> None:
         """Adds a status_data object to the queue."""
         logger.debug(
-            "Data added to queue. Queue now has length %s", self.queue.qsize() + 1
+            "K8s release status data added to queue. Queue now has length %s", self.queue.qsize() + 1
         )
         self.queue.put(status_data)
 

--- a/serve_event_listener/status_queue.py
+++ b/serve_event_listener/status_queue.py
@@ -1,9 +1,11 @@
 import logging
 import queue
-import requests
 import threading
 import time
 from datetime import datetime, timezone
+
+import requests
+
 from serve_event_listener.http_client import post as http_post
 
 logger = logging.getLogger(__name__)
@@ -28,7 +30,8 @@ class StatusQueue:
     def add(self, status_data) -> None:
         """Adds a status_data object to the queue."""
         logger.debug(
-            "K8s release status data added to queue. Queue now has length %s", self.queue.qsize() + 1
+            "K8s release status data added to queue. Queue now has length %s",
+            self.queue.qsize() + 1,
         )
         self.queue.put(status_data)
 

--- a/serve_event_listener/status_queue.py
+++ b/serve_event_listener/status_queue.py
@@ -1,28 +1,40 @@
 import logging
 import queue
+import requests
 import threading
 import time
 from datetime import datetime, timezone
+from serve_event_listener.http_client import post as http_post
 
 logger = logging.getLogger(__name__)
 
 
 class StatusQueue:
-    def __init__(self, post_handler, token):
+    """
+    StatusQueue represents a queue of k8s pod statuses to process.
+    """
+
+    def __init__(
+        self, session: requests.Session, url: str, token: str, token_fetcher=None
+    ):
         self.queue = queue.Queue()
         self.stop_event = threading.Event()
 
-        # The post handler is a function that is set by the EventListener class
-        self.post_handler = post_handler
+        self.session = session
+        self.url = url
+        # self.post_handler = post_handler
         self.token = token
+        self.token_fetcher = token_fetcher
 
-    def add(self, status_data):
+    def add(self, status_data) -> None:
+        """Adds a status_data object to the queue."""
         logger.debug(
-            f"Data added to queue. Queue now has length {self.queue.qsize()+1}"
+            "Data added to queue. Queue now has length %s", self.queue.qsize() + 1
         )
         self.queue.put(status_data)
 
-    def process(self):
+    def process(self) -> None:
+        """Process the queue in a loop until a stop event is detected."""
         log_cnt_q_is_empty: int = 0
         do_wait: bool = False
 
@@ -41,7 +53,7 @@ class StatusQueue:
 
                 if new_status == "Deleted":
                     logger.info(
-                        f"Processing release: {release}. New status is Deleted!"
+                        "Processing release: %s. New status is Deleted!", release
                     )
 
                     event_ts = datetime.strptime(
@@ -60,15 +72,37 @@ class StatusQueue:
                         do_wait = True
                         continue
 
-                self.post_handler(
+                headers = {
+                    "Authorization": f"Token {self.token}",
+                    "Content-Type": "application/json",
+                }
+                resp = http_post(
+                    self.session,
+                    self.url,
                     data=status_data,
-                    headers={"Authorization": f"Token {self.token}"},
+                    headers=headers,
+                    token_fetcher=self.token_fetcher,
                 )
 
                 self.queue.task_done()
 
+                if resp is None:
+                    logger.warning(
+                        "POST failed: network/transport error (wrapper returned None)"
+                    )
+                elif resp.status_code >= 400:
+                    logger.warning(
+                        "POST failed: status %s body=%s",
+                        resp.status_code,
+                        (resp.text or "")[:200],
+                    )
+                else:
+                    logger.debug("POST ok: %s", resp.status_code)
+
                 logger.debug(
-                    f"Processed queue successfully of release {release}, new status={new_status}"
+                    "Processed queue successfully of release %s, new status=%s",
+                    release,
+                    new_status,
                 )
                 log_cnt_q_is_empty = 0
             except queue.Empty:
@@ -81,6 +115,7 @@ class StatusQueue:
                 log_cnt_q_is_empty += 1
                 # pass  # Continue looping if the queue is empty
 
-    def stop_processing(self):
+    def stop_processing(self) -> None:
+        """Stop processing the queue."""
         logger.warning("Queue processing stopped")
         self.stop_event.set()

--- a/tests/http_client/test_http_helpers.py
+++ b/tests/http_client/test_http_helpers.py
@@ -1,0 +1,194 @@
+import unittest
+from unittest.mock import MagicMock
+from urllib3.util.retry import Retry
+import requests
+from requests.adapters import HTTPAdapter
+from serve_event_listener.http_client import make_session, _request
+
+
+class TestMakeSession(unittest.TestCase):
+    """Tests for make_session: adapter mounts and retry policy."""
+
+    def test_make_session_mounts_and_retries(self):
+        """Test that make_session mounts correctly and Retry config is set as expected."""
+        s = make_session(total_retries=3)
+        https_adapter = s.get_adapter("https://")
+
+        # Assert correct adapter type
+        self.assertIsInstance(https_adapter, HTTPAdapter)
+
+        # Assert Retry policy
+        r = https_adapter.max_retries
+        self.assertIsInstance(r, Retry)
+        self.assertEqual(r.total, 3)
+        self.assertIn("GET", r.allowed_methods)
+        self.assertIn(503, r.status_forcelist)
+
+
+class TestRequestRetryLogic(unittest.TestCase):
+    """
+    Test retry behavior in _request for 5xx errors, timeouts, and token refresh.
+    The tests pass in faked sleep_fn arguments rather than patching time.sleep.
+    """
+
+    def setUp(self):
+        """Create a mock session for all tests."""
+        self.mock_session = MagicMock()
+        self.mock_session.headers = {"Accept": "application/json"}
+
+    def test_retry_on_500_error(self):
+        """Test that _request retries on 500 errors and succeeds on the second attempt."""
+        # Setup a mock to track sleep calls, instead of patching sleep
+        sleep_calls = []
+
+        def track_sleep(delay):
+            sleep_calls.append(delay)
+
+        # Setup: First call returns 500, second returns 200
+        mock_resp_500 = MagicMock(status_code=500)
+        mock_resp_200 = MagicMock(status_code=200)
+        mock_resp_200.json.return_value = {"success": True}
+        self.mock_session.request.side_effect = [mock_resp_500, mock_resp_200]
+
+        response = _request(
+            session=self.mock_session,
+            method="GET",
+            url="http://fake.url",
+            backoff_seconds=(0.1, 0.2),  # Short backoff for testing
+            sleep_fn=track_sleep,  # Use our tracking function
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(self.mock_session.request.call_count, 2)
+        # One sleep between attempts; status 200 returns immediately
+        self.assertEqual(len(sleep_calls), 1)
+        self.assertEqual(sleep_calls[0], 0.1)  # First backoff value
+
+    def test_retry_exhausted_on_500(self):
+        """Test that _request stops retrying after exhausting backoff_seconds."""
+        # Setup a mock to track sleep calls, instead of patching sleep
+        sleep_calls = []
+
+        def track_sleep(delay):
+            sleep_calls.append(delay)
+
+        # Setup: All 3 calls return 500 (no success)
+        mock_resp_500 = MagicMock(status_code=500)
+        self.mock_session.request.side_effect = [mock_resp_500] * 2  # 2 failures
+
+        response = _request(
+            session=self.mock_session,
+            method="GET",
+            url="http://fake.url",
+            backoff_seconds=(0.1, 0.2),
+            sleep_fn=track_sleep,  # Use our tracking function
+        )
+
+        # Assert
+        self.assertEqual(
+            response.status_code, 500
+        )  # The final status code should be 500
+        self.assertEqual(self.mock_session.request.call_count, 2)  # Max 2 attempts
+        self.assertEqual(len(sleep_calls), 1)  # One sleep between attempts
+        self.assertEqual(sleep_calls[0], 0.1)  # First backoff value
+
+    def test_no_retry_on_400_or_404(self):
+        """Test that _request does NOT retry on 400 or 404 errors."""
+        mock_resp_400 = MagicMock(status_code=400)
+        self.mock_session.request.return_value = mock_resp_400
+
+        response = _request(
+            session=self.mock_session,
+            method="GET",
+            url="http://fake.url",
+            backoff_seconds=(0.1, 0.2),
+            sleep_fn=lambda x: None,
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.mock_session.request.assert_called_once()  # No retry
+
+    def test_token_refresh_on_401(self):
+        """Test that _request refreshes the token on 401 and retries successfully."""
+        # Setup: First call returns 401, second succeeds after refresh
+        mock_resp_401 = MagicMock(status_code=401)
+        mock_resp_200 = MagicMock(status_code=200)
+        mock_resp_200.json.return_value = {"data": "refreshed"}
+        self.mock_session.request.side_effect = [mock_resp_401, mock_resp_200]
+
+        # Mock token fetcher
+        def mock_token_fetcher():
+            return "new_token"
+
+        response = _request(
+            session=self.mock_session,
+            method="POST",
+            url="http://fake.url",
+            json={"key": "value"},
+            token_fetcher=mock_token_fetcher,
+            backoff_seconds=(0.1, 0.2),
+            sleep_fn=lambda x: None,
+        )
+
+        # Assert
+        self.assertEqual(self.mock_session.request.call_count, 2)
+        self.assertEqual(response.json(), {"data": "refreshed"})
+
+        # Verify the second call uses the new token
+        second_call_headers = self.mock_session.request.call_args_list[1][1]["headers"]
+        self.assertEqual(second_call_headers["Authorization"], "Bearer new_token")
+
+    def test_timeout_handling(self):
+        """Test that _request handles timeouts gracefully and returns None."""
+        self.mock_session.request.side_effect = requests.exceptions.Timeout(
+            "Fake timeout"
+        )
+
+        response = _request(
+            session=self.mock_session,
+            method="GET",
+            url="http://fake.url",
+            backoff_seconds=(0.1,),
+            sleep_fn=lambda x: None,
+        )
+
+        # Assert
+        self.assertIsNone(response)
+        self.mock_session.request.assert_called_once()
+
+    def test_connection_error_handling(self):
+        """Test that _request handles connection errors and returns None."""
+        self.mock_session.request.side_effect = requests.exceptions.ConnectionError(
+            "Fake error"
+        )
+
+        response = _request(
+            session=self.mock_session,
+            method="GET",
+            url="http://fake.url",
+            backoff_seconds=(0.1,),
+            sleep_fn=lambda x: None,
+        )
+
+        # Assert
+        self.assertIsNone(response)
+        self.mock_session.request.assert_called_once()
+
+    def test_empty_backoff_raises(self):
+        """_request should raise if backoff_seconds is empty"""
+        with self.assertRaises(ValueError) as ctx:
+            _request(
+                session=self.mock_session,
+                method="GET",
+                url="http://fake.url",
+                backoff_seconds=(),
+                sleep_fn=lambda x: None,
+            )
+        self.assertIn("backoff_seconds", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/http_client/test_http_helpers.py
+++ b/tests/http_client/test_http_helpers.py
@@ -139,7 +139,7 @@ class TestRequestRetryLogic(unittest.TestCase):
 
         # Verify the second call uses the new token
         second_call_headers = self.mock_session.request.call_args_list[1][1]["headers"]
-        self.assertEqual(second_call_headers["Authorization"], "Bearer new_token")
+        self.assertEqual(second_call_headers["Authorization"], "Token new_token")
 
     def test_timeout_handling(self):
         """Test that _request handles timeouts gracefully and returns None."""

--- a/tests/http_client/test_http_helpers.py
+++ b/tests/http_client/test_http_helpers.py
@@ -1,9 +1,11 @@
 import unittest
 from unittest.mock import MagicMock
-from urllib3.util.retry import Retry
+
 import requests
 from requests.adapters import HTTPAdapter
-from serve_event_listener.http_client import make_session, _request
+from urllib3.util.retry import Retry
+
+from serve_event_listener.http_client import _request, make_session
 
 
 class TestMakeSession(unittest.TestCase):

--- a/tests/test_event_listener.py
+++ b/tests/test_event_listener.py
@@ -1,0 +1,193 @@
+import logging
+import unittest
+from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+import requests
+
+from serve_event_listener.event_listener import EventListener
+
+
+class TestEventListener(unittest.TestCase):
+    """Test the EventListener logic by mocking away the server API and Kubernetes."""
+
+    def setUp(self):
+        """Create a fresh EventListener for each test."""
+        self.el = EventListener()
+
+    # ---------- check_serve_api_status ----------
+
+    @patch("serve_event_listener.event_listener.http_get")
+    def test_check_serve_api_status_true(self, mock_get):
+        """Returns True on HTTP 200."""
+        mock_get.return_value = MagicMock(status_code=200)
+        self.assertTrue(self.el.check_serve_api_status())
+        mock_get.assert_called_once()
+
+    @patch("serve_event_listener.event_listener.http_get")
+    def test_check_serve_api_status_false_on_none(self, mock_get):
+        """Returns False when wrapper returns None."""
+        mock_get.return_value = None
+        self.assertFalse(self.el.check_serve_api_status())
+
+    # ---------- fetch_token ----------
+
+    @patch("serve_event_listener.event_listener.http_post")
+    def test_fetch_token_success(self, mock_post):
+        """Returns token and updates self.token on success."""
+        r = MagicMock(status_code=200)
+        r.json.return_value = {"token": "T123"}
+        mock_post.return_value = r
+
+        token = self.el.fetch_token()
+        self.assertEqual(token, "T123")
+        self.assertEqual(self.el.token, "T123")
+
+    @patch("serve_event_listener.event_listener.http_post")
+    def test_fetch_token_network_failure_raises(self, mock_post):
+        """Raises RequestException on network failure (None)."""
+        mock_post.return_value = None
+        with self.assertRaises(requests.exceptions.RequestException):
+            self.el.fetch_token()
+
+    @patch("serve_event_listener.event_listener.http_post")
+    def test_fetch_token_non_json_raises(self, mock_post):
+        """Raises RequestException on non-JSON body."""
+        r = MagicMock(status_code=200)
+        r.json.side_effect = ValueError("not json")
+        mock_post.return_value = r
+        with self.assertRaises(requests.exceptions.RequestException):
+            self.el.fetch_token()
+
+    @patch("serve_event_listener.event_listener.http_post")
+    def test_fetch_token_missing_token_raises(self, mock_post):
+        """Raises KeyError when 'token' field is missing."""
+        r = MagicMock(status_code=200)
+        r.json.return_value = {"nope": "x"}
+        mock_post.return_value = r
+        with self.assertRaises(KeyError):
+            self.el.fetch_token()
+
+    @patch("serve_event_listener.event_listener.http_post")
+    def test_fetch_token_non_200_raises(self, mock_post):
+        """Raises RequestException on non-200 status."""
+        r = MagicMock(status_code=401, text="unauthorized")
+        mock_post.return_value = r
+        with self.assertRaises(requests.exceptions.RequestException):
+            self.el.fetch_token()
+
+    # ---------- setup_client ----------
+
+    @patch("serve_event_listener.event_listener.watch.Watch")
+    @patch("serve_event_listener.event_listener.client.CoreV1Api")
+    @patch("serve_event_listener.event_listener.client.ApiClient")
+    @patch("serve_event_listener.event_listener.client.Configuration.get_default_copy")
+    @patch("serve_event_listener.event_listener.os.path.exists", return_value=True)
+    @patch("serve_event_listener.event_listener.config.load_kube_config")
+    def test_setup_client_uses_kubeconfig(
+        self, mock_load, _exists, mock_cfg, _api, _core, _watch
+    ):
+        """Uses kubeconfig when KUBECONFIG path exists."""
+        mock_cfg.return_value = SimpleNamespace(debug=False)
+        with patch(
+            "serve_event_listener.event_listener.KUBECONFIG", "/app/cluster.conf"
+        ):
+            self.el.setup_client()
+        mock_load.assert_called_once_with("/app/cluster.conf")
+
+    @patch("serve_event_listener.event_listener.watch.Watch")
+    @patch("serve_event_listener.event_listener.client.CoreV1Api")
+    @patch("serve_event_listener.event_listener.client.ApiClient")
+    @patch("serve_event_listener.event_listener.client.Configuration.get_default_copy")
+    @patch("serve_event_listener.event_listener.os.path.exists", return_value=False)
+    @patch(
+        "serve_event_listener.event_listener.config.incluster_config.load_incluster_config"
+    )
+    def test_setup_client_uses_incluster(
+        self, mock_incluster, _exists, mock_cfg, _api, _core, _watch
+    ):
+        """Falls back to in-cluster config when no kubeconfig."""
+        mock_cfg.return_value = SimpleNamespace(debug=False)
+        with patch("serve_event_listener.event_listener.KUBECONFIG", None):
+            self.el.setup_client()
+        mock_incluster.assert_called_once()
+
+    # ---------- get_resource_version_from_pod_list ----------
+
+    def test_get_resource_version_from_pod_list(self):
+        """Returns resourceVersion from pod list."""
+        self.el.client = MagicMock()
+        self.el.client.list_namespaced_pod.return_value = SimpleNamespace(
+            metadata=SimpleNamespace(resource_version="rv-123")
+        )
+        rv = self.el.get_resource_version_from_pod_list()
+        self.assertEqual(rv, "rv-123")
+        self.el.client.list_namespaced_pod.assert_called_once()
+
+    # ---------- setup (happy path) ----------
+
+    @patch("serve_event_listener.event_listener.StatusQueue")
+    @patch.object(EventListener, "setup_client")
+    @patch.object(EventListener, "check_serve_api_status", return_value=True)
+    @patch.object(EventListener, "fetch_token", return_value="T1")
+    def test_setup_constructs_queue(self, _fetch, _check, mock_setup_client, mock_SQ):
+        """Builds StatusQueue with shared session and token."""
+
+        # When setup_client() is called, simulate it creating the client attribute
+        mock_setup_client.side_effect = lambda *a, **k: setattr(
+            self.el, "client", MagicMock()
+        )
+
+        # Avoid any work inside StatusData
+        self.el._status_data = MagicMock()
+
+        self.el.setup()
+        self.assertTrue(self.el.setup_complete)
+        mock_SQ.assert_called_once()
+        args, _ = mock_SQ.call_args
+        self.assertIs(args[0], self.el.session)  # session shared
+        self.assertIsInstance(args[1], str)  # endpoint
+        self.assertEqual(args[2], "T1")  # token
+
+    # ---------- listen (single event then stop) ----------
+
+    @patch("serve_event_listener.event_listener.time.sleep", return_value=None)
+    @patch("serve_event_listener.event_listener.threading.Thread")
+    def test_listen_processes_event_and_stops_on_exception(self, mock_thread, _sleep):
+        """Processes one event and stops on exception."""
+        mock_thread.return_value.start.return_value = None
+
+        self.el.setup_complete = True
+        self.el._status_queue = MagicMock()
+        self.el._status_data = MagicMock()
+        self.el._status_data.get_post_data.return_value = {"p": 1}
+        self.el.client = MagicMock()
+        self.el.client.list_namespaced_pod.return_value = SimpleNamespace(
+            metadata=SimpleNamespace(resource_version="rv0")
+        )
+
+        logging.disable(logging.CRITICAL)
+
+        def stream_fn(*_a, **_k):
+            yield {
+                "object": SimpleNamespace(
+                    metadata=SimpleNamespace(resource_version="rv1")
+                )
+            }
+            raise Exception(
+                "OK. Intentionally raised exception to verify stop processing queue"
+            )
+
+        self.el.watch = MagicMock()
+        self.el.watch.stream.side_effect = stream_fn
+
+        self.el.listen()
+
+        self.el._status_data.update.assert_called_once()
+        self.el._status_queue.add.assert_called_once_with({"p": 1})
+        self.el._status_queue.stop_processing.assert_called_once()
+
+        logging.disable(logging.NOTSET)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_event_listener.py
+++ b/tests/test_event_listener.py
@@ -1,7 +1,8 @@
 import logging
 import unittest
-from unittest.mock import patch, MagicMock
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import requests
 
 from serve_event_listener.event_listener import EventListener

--- a/tests/test_status_data.py
+++ b/tests/test_status_data.py
@@ -23,6 +23,8 @@ else:
 
 
 class TestPodProcessing(unittest.TestCase):
+    """This test case simulates a realistic processing flow of a deployed pod."""
+
     release = "some_release"
 
     def setUp(self) -> None:
@@ -52,6 +54,26 @@ class TestPodProcessing(unittest.TestCase):
 
         time.sleep(0.01)
 
+        self.pod.delete()
+
+        event = {"object": self.pod}
+        self.status_data.update(event)
+
+        assert (
+            self.status_data.status_data[release].get("status") == "Terminated"
+        )  # before: Deleted
+
+    def test_pod_delete_nonexisting_pod(self):
+        """
+        This tests that a k8s watch event with a delete action of a
+        non-existing pod is still handled in a safe manner.
+        """
+        release = "r1234567"
+
+        # Create the pod object but do not add the create event!
+        self.pod.create(release)
+
+        # Now delete the pod that lacks a create event
         self.pod.delete()
 
         event = {"object": self.pod}
@@ -96,7 +118,8 @@ class TestPodProcessing(unittest.TestCase):
         """
         This scenario creates a pod, then creates a new pod.
         After the second pod is created, the first one is deleted.
-        This is similar to how replicasets work"""
+        This is similar to how replicasets work.
+        """
 
         release = "r1234567"
 

--- a/tests/test_status_queue.py
+++ b/tests/test_status_queue.py
@@ -1,0 +1,136 @@
+import unittest
+import threading
+import time
+from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+
+import requests
+from serve_event_listener.status_queue import StatusQueue
+
+
+class TestStatusQueue(unittest.TestCase):
+    def setUp(self):
+        """Create a queue with a shared fake Session and defaults."""
+        self.session = MagicMock(spec=requests.Session)
+        self.url = "https://api.fake.url/app-status"
+        self.token = "T0"
+
+    # ---------- add() ----------
+
+    def test_add_enqueues_item(self):
+        """add() places one item on the queue."""
+        q = StatusQueue(self.session, self.url, self.token)
+        item = {
+            "release": "r1",
+            "new-status": "Running",
+            "event-ts": "2025-01-01T00:00:00.000000Z",
+        }
+        q.add(item)
+        self.assertEqual(q.queue.qsize(), 1)
+
+    # ---------- process(): happy path (exposes early-return bug) ----------
+
+    @patch("serve_event_listener.status_queue.http_post")
+    def test_process_handles_multiple_items(self, mock_post):
+        """process() should send all items (will FAIL until early-return is fixed)."""
+        mock_post.return_value = SimpleNamespace(status_code=200)
+
+        q = StatusQueue(self.session, self.url, self.token)
+
+        # Two items to process
+        q.add(
+            {
+                "release": "r1",
+                "new-status": "Running",
+                "event-ts": "2025-01-01T00:00:00.000000Z",
+            }
+        )
+        q.add(
+            {
+                "release": "r2",
+                "new-status": "Running",
+                "event-ts": "2025-01-01T00:00:00.000000Z",
+            }
+        )
+
+        t = threading.Thread(target=q.process, daemon=True)
+        t.start()
+
+        # Give the worker a moment to process
+        time.sleep(0.1)
+        q.stop_processing()
+        t.join(timeout=1)
+
+        # Expect two posts; current code returns after first -> this test will show 1
+        self.assertEqual(
+            mock_post.call_count, 2, "Early return in process() prevents second item"
+        )
+
+    # ---------- process(): Deleted event requeue (<30s) ----------
+
+    @patch("serve_event_listener.status_queue.time.sleep", return_value=None)
+    @patch("serve_event_listener.status_queue.http_post")
+    def test_deleted_recent_is_requeued_and_not_posted(self, mock_post, _sleep):
+        """Deleted events <30s old should be requeued and not posted."""
+        # Event timestamp ~now to trigger requeue path
+        from datetime import datetime, timezone
+
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+        q = StatusQueue(self.session, self.url, self.token)
+        q.add({"release": "r1", "new-status": "Deleted", "event-ts": now_iso})
+
+        t = threading.Thread(target=q.process, daemon=True)
+        t.start()
+
+        # Let it cycle once (pop, requeue)
+        time.sleep(0.05)
+        q.stop_processing()
+        t.join(timeout=1)
+
+        # Should not have posted anything
+        self.assertEqual(mock_post.call_count, 0)
+
+        # Item was requeued at least once
+        self.assertGreaterEqual(q.queue.qsize(), 1)
+
+    # ---------- headers passed to http_post ----------
+
+    @patch("serve_event_listener.status_queue.http_post")
+    def test_headers_include_bearer_token(self, mock_post):
+        """Authorization header should include current Bearer/Token token."""
+        mock_post.return_value = SimpleNamespace(status_code=200)
+        q = StatusQueue(self.session, self.url, "T123")
+
+        q.add(
+            {
+                "release": "r1",
+                "new-status": "Running",
+                "event-ts": "2025-01-01T00:00:00.000000Z",
+            }
+        )
+
+        t = threading.Thread(target=q.process, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        q.stop_processing()
+        t.join(timeout=1)
+
+        # Inspect headers from the first call
+        _, kwargs = mock_post.call_args
+        headers = kwargs["headers"]
+        self.assertEqual(headers["Authorization"], "Token T123")
+        self.assertEqual(headers["Content-Type"], "application/json")
+
+    # ---------- stop_processing() ----------
+
+    def test_stop_processing_sets_event(self):
+        """stop_processing() sets the stop event flag."""
+        q = StatusQueue(self.session, self.url, self.token)
+        self.assertFalse(q.stop_event.is_set())
+        q.stop_processing()
+        self.assertTrue(q.stop_event.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_queue.py
+++ b/tests/test_status_queue.py
@@ -1,10 +1,11 @@
-import unittest
 import threading
 import time
-from unittest.mock import patch, MagicMock
+import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import requests
+
 from serve_event_listener.status_queue import StatusQueue
 
 


### PR DESCRIPTION
This PR adds a fix to bug that occurs when the k8s event stream registers a delete event but the app (release) is not registered in the EL status queue. It also:
- modifies Dockerfile to /app layout and main as module execution
- adds an http_client subpackage with session and client wrappers to separate HTTP concerns
- installs jq into the docker container
- adds several new unit test classes for better test coverage

Note that kubeconfig is now expected at /app/cluster.conf inside the container (impacts docker compose of stackn project).