### PR TITLE
ss-1721 Upgrade k8s Python client version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-kubernetes>=32.0.0,<32.1
+kubernetes==33.1.0
 colorlog==6.9.0

--- a/serve_event_listener/status_data.py
+++ b/serve_event_listener/status_data.py
@@ -344,11 +344,9 @@ class StatusData:
                 StatusData.determine_status_from_k8s(status_object)
             )
 
-            logger.debug(
-                f"Pod status converted to AppStatus={status}, \
+            logger.debug(f"Pod status converted to AppStatus={status}, \
                          ContMessage:{container_message}, \
-                         PodMessage:{pod_message}"
-            )
+                         PodMessage:{pod_message}")
 
             creation_timestamp = pod.metadata.creation_timestamp
             deletion_timestamp = pod.metadata.deletion_timestamp


### PR DESCRIPTION
Jira: https://scilifelab.atlassian.net/browse/SS-1721
Doc: https://scilifelab.atlassian.net/wiki/x/D4CL_Q

Moving from Kubernetes v1.32 to v1.33 requires an upgrade to the Python client as seen [here](https://github.com/kubernetes-client/python#compatibility).